### PR TITLE
chore: update snyk projects endpoint to new api

### DIFF
--- a/main.go
+++ b/main.go
@@ -340,8 +340,7 @@ func collect(ctx context.Context, client *client, organization org, target strin
 			project:     project.Attributes.Name,
 			projectType: project.Attributes.Type,
 			results:     results,
-			// isMonitored: project.IsMonitored,
-			isMonitored: true, // TODO: FIX THIS
+			isMonitored: project.Attributes.Status == "active",
 		})
 		log.Debugf("Collected data in %v for %s %s", duration, project.ID, project.Attributes.Name)
 		// stop right away in case of the context being cancelled. This ensures that

--- a/main.go
+++ b/main.go
@@ -323,26 +323,27 @@ func collect(ctx context.Context, client *client, organization org, target strin
 	}
 
 	var gaugeResults []gaugeResult
-	for _, project := range projects.Projects {
+	for _, project := range projects.Data {
 		start := time.Now()
 		issues, err := client.getIssues(organization.ID, project.ID)
 		duration := time.Since(start)
 		if err != nil {
-			log.Errorf("Failed to get issues for organization %s (%s) and project %s (%s): duration %v:  %v", organization.Name, organization.ID, project.Name, project.ID, duration, err)
+			log.Errorf("Failed to get issues for organization %s (%s) and project %s (%s): duration %v:  %v", organization.Name, organization.ID, project.Attributes.Name, project.ID, duration, err)
 			continue
 		}
 		results := aggregateIssues(issues.Issues)
 
 		gaugeResults = append(gaugeResults, gaugeResult{
 			organization: organization.Name,
-			target:       strings.Split(project.Name, ":")[0],
+			target:       strings.Split(project.Attributes.Name, ":")[0],
 			//target:      project.Name,
-			project:     project.Name,
-			projectType: project.ProjectType,
+			project:     project.Attributes.Name,
+			projectType: project.Attributes.Type,
 			results:     results,
-			isMonitored: project.IsMonitored,
+			// isMonitored: project.IsMonitored,
+			isMonitored: true, // TODO: FIX THIS
 		})
-		log.Debugf("Collected data in %v for %s %s", duration, project.ID, project.Name)
+		log.Debugf("Collected data in %v for %s %s", duration, project.ID, project.Attributes.Name)
 		// stop right away in case of the context being cancelled. This ensures that
 		// we don't wait for a complete collect run for all projects before
 		// stopping.

--- a/main_test.go
+++ b/main_test.go
@@ -185,7 +185,7 @@ func TestRunAPIPolling_issuesTimeout(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		// passing server.URL twice -- once as the legacy url and once as the modern url
-		err := runAPIPolling(ctx, server.URL, server.URL, "token", nil, nil, 20*time.Millisecond, 1*time.Millisecond)
+		err := runAPIPolling(ctx, server.URL, server.URL, "2023-06-22", "token", nil, nil, 20*time.Millisecond, 1*time.Millisecond)
 		if err != nil {
 			t.Errorf("unexpected error result: %v", err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -184,7 +184,8 @@ func TestRunAPIPolling_issuesTimeout(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := runAPIPolling(ctx, server.URL, "token", nil, nil, 20*time.Millisecond, 1*time.Millisecond)
+		// passing server.URL twice -- once as the legacy url and once as the modern url
+		err := runAPIPolling(ctx, server.URL, server.URL, "token", nil, nil, 20*time.Millisecond, 1*time.Millisecond)
 		if err != nil {
 			t.Errorf("unexpected error result: %v", err)
 		}

--- a/snyk.go
+++ b/snyk.go
@@ -56,12 +56,6 @@ func (c *client) getProjects(organizationID string, target string) (projectsResp
 		return projectsResponse{}, err
 	}
 
-	// resDump, err := httputil.DumpResponse(response, true)
-	// log.Info(string(resDump))
-
-	b, err := ioutil.ReadAll(response.Body)
-	log.Info(string(b))
-
 	var projects projectsResponse
 	err = json.NewDecoder(response.Body).Decode(&projects)
 	if err != nil {
@@ -137,9 +131,9 @@ type org struct {
 }
 
 type projectsResponse struct {
-	JsonApi jsonApi   `json:"jsonapi,omitempty"`
-	Data    []project `json:"data,omitempty"`
-	Links   links     `json:"links,omitEmpty"`
+	JsonApi jsonApi      `json:"jsonapi,omitempty"`
+	Data    []project    `json:"data,omitempty"`
+	Links   projectLinks `json:"links,omitEmpty"`
 }
 
 type jsonApi struct {
@@ -159,18 +153,18 @@ type projectMeta struct {
 }
 
 type projectAttributes struct {
-	Name                string            `json:"name,omitempty"`
-	Type                string            `json:"type,omitempty"`
-	TargetFile          string            `json:"target_file,omitempty"`
-	TargetReference     string            `json:"target_reference,omitempty"`
-	Origin              string            `json:"origin,omitempty"`
-	Created             string            `json:"created,omitempty"`
-	Status              string            `json:"status,omitempty"`
-	BusinessCriticality []string          `json:"business_criticality,omitempty"`
-	Environment         []string          `json:"environment,omitempty"`
-	Lifecycle           []string          `json:"lifecycle,omitempty"`
-	Tags                []projectTag      `json:"tags,omitempty"`
-	Settings            []projectSettings `json:"settings,omitempty"`
+	Name                string          `json:"name,omitempty"`
+	Type                string          `json:"type,omitempty"`
+	TargetFile          string          `json:"target_file,omitempty"`
+	TargetReference     string          `json:"target_reference,omitempty"`
+	Origin              string          `json:"origin,omitempty"`
+	Created             string          `json:"created,omitempty"`
+	Status              string          `json:"status,omitempty"`
+	BusinessCriticality []string        `json:"business_criticality,omitempty"`
+	Environment         []string        `json:"environment,omitempty"`
+	Lifecycle           []string        `json:"lifecycle,omitempty"`
+	Tags                []projectTag    `json:"tags,omitempty"`
+	Settings            projectSettings `json:"settings,omitempty"`
 }
 
 type projectTag struct {
@@ -211,7 +205,7 @@ type projectRelationshipLinks struct {
 	Related string `json:"related,omitempty"`
 }
 
-type links struct {
+type projectLinks struct {
 	Next string `json:"next,omitempty"`
 }
 

--- a/snyk.go
+++ b/snyk.go
@@ -12,9 +12,10 @@ import (
 )
 
 type client struct {
-	httpClient *http.Client
-	token      string
-	baseURL    string
+	httpClient    *http.Client
+	token         string
+	baseLegacyUrl string
+	baseURL       string
 }
 
 func (c *client) getOrganizations() (orgsResponse, error) {
@@ -74,7 +75,7 @@ func (c *client) getIssues(organizationID, projectID string) (issuesResponse, er
 	if err != nil {
 		return issuesResponse{}, err
 	}
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/org/%s/project/%s/aggregated-issues", c.baseURL, organizationID, projectID), &reader)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/org/%s/project/%s/aggregated-issues", c.baseLegacyUrl, organizationID, projectID), &reader)
 	if err != nil {
 		return issuesResponse{}, err
 	}

--- a/snyk.go
+++ b/snyk.go
@@ -220,13 +220,6 @@ type links struct {
 	Next string `json:"next,omitempty"`
 }
 
-// type project struct {
-// 	Name        string `json:"name,omitempty"`
-// 	ID          string `json:"id,omitempty"`
-// 	ProjectType string `json:"type,omitempty"`
-// 	IsMonitored bool   `json:"isMonitored,omitempty"`
-// }
-
 type issuesResponse struct {
 	Issues []issue `json:"issues,omitempty"`
 }

--- a/snyk.go
+++ b/snyk.go
@@ -55,6 +55,13 @@ func (c *client) getProjects(organizationID string, target string) (projectsResp
 	if err != nil {
 		return projectsResponse{}, err
 	}
+
+	// resDump, err := httputil.DumpResponse(response, true)
+	// log.Info(string(resDump))
+
+	b, err := ioutil.ReadAll(response.Body)
+	log.Info(string(b))
+
 	var projects projectsResponse
 	err = json.NewDecoder(response.Body).Decode(&projects)
 	if err != nil {
@@ -129,22 +136,96 @@ type org struct {
 	} `json:"group,omitempty"`
 }
 
+// type projectsResponse struct {
+// 	Org      projectOrg `json:"org,omitempty"`
+// 	Projects []project  `json:"projects,omitempty"`
+// }
+
 type projectsResponse struct {
-	Org      projectOrg `json:"org,omitempty"`
-	Projects []project  `json:"projects,omitempty"`
+	JsonApi jsonApi   `json:"jsonapi,omitempty"`
+	Data    []project `json:"data,omitempty"`
+	Links   links     `json:"links,omitEmpty"`
 }
 
-type projectOrg struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+type jsonApi struct {
+	Version string `json:"version,omitempty"`
 }
 
 type project struct {
-	Name        string `json:"name,omitempty"`
-	ID          string `json:"id,omitempty"`
-	ProjectType string `json:"type,omitempty"`
-	IsMonitored bool   `json:"isMonitored,omitempty"`
+	Type          string               `json:"type,omitempty"`
+	ID            string               `json:"id,omitempty"`
+	Meta          projectMeta          `json:"meta,omitempty"`
+	Attributes    projectAttributes    `json:"attributes,omitempty"`
+	Relationships projectRelationships `json:"relationships,omitempty"`
 }
+
+type projectMeta struct {
+	MonitoredAt string `json:"cli_monitored_at,omitempty"`
+}
+
+type projectAttributes struct {
+	Name                string            `json:"name,omitempty"`
+	Type                string            `json:"type,omitempty"`
+	TargetFile          string            `json:"target_file,omitempty"`
+	TargetReference     string            `json:"target_reference,omitempty"`
+	Origin              string            `json:"origin,omitempty"`
+	Created             string            `json:"created,omitempty"`
+	Status              string            `json:"status,omitempty"`
+	BusinessCriticality []string          `json:"business_criticality,omitempty"`
+	Environment         []string          `json:"environment,omitempty"`
+	Lifecycle           []string          `json:"lifecycle,omitempty"`
+	Tags                []projectTag      `json:"tags,omitempty"`
+	Settings            []projectSettings `json:"settings,omitempty"`
+}
+
+type projectTag struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+type projectSettings struct {
+	RecurringTests projectSettingsRecurringTests `json:"recurring_tests,omitempty"`
+	PullRequests   projectSettingsPullRequests   `json:"pull_requests,omitempty"`
+}
+
+type projectSettingsRecurringTests struct {
+	Frequency string `json:"frequency,omitempty"`
+}
+
+type projectSettingsPullRequests struct {
+	FailOnlyForIssuesWithFix bool `json:"fail_only_for_issues_with_fix,omitempty"`
+}
+
+type projectRelationships struct {
+	Organization projectRelationship `json:"organization,omitempty"`
+	Target       projectRelationship `json:"target,omitempty"`
+	Importer     projectRelationship `json:"importer,omitempty"`
+}
+
+type projectRelationship struct {
+	Data  projectRelationshipData  `json:"data,omitempty"`
+	Links projectRelationshipLinks `json:"links,omitempty"`
+}
+
+type projectRelationshipData struct {
+	Type string `json:"type,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+type projectRelationshipLinks struct {
+	Related string `json:"related,omitempty"`
+}
+
+type links struct {
+	Next string `json:"next,omitempty"`
+}
+
+// type project struct {
+// 	Name        string `json:"name,omitempty"`
+// 	ID          string `json:"id,omitempty"`
+// 	ProjectType string `json:"type,omitempty"`
+// 	IsMonitored bool   `json:"isMonitored,omitempty"`
+// }
 
 type issuesResponse struct {
 	Issues []issue `json:"issues,omitempty"`

--- a/snyk.go
+++ b/snyk.go
@@ -136,11 +136,6 @@ type org struct {
 	} `json:"group,omitempty"`
 }
 
-// type projectsResponse struct {
-// 	Org      projectOrg `json:"org,omitempty"`
-// 	Projects []project  `json:"projects,omitempty"`
-// }
-
 type projectsResponse struct {
 	JsonApi jsonApi   `json:"jsonapi,omitempty"`
 	Data    []project `json:"data,omitempty"`


### PR DESCRIPTION
Resolves https://github.com/grafana/security-internal/issues/228

Use the Snyk REST api for the `/orgs/{organization}/projects` endpoint.

Snyk's migration guide:
https://go.snyk.io/rs/677-THP-415/images/Snyk%20v1%20API%20Migration%20Guide.pdf