### PR TITLE
Adding more filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,75 +4,92 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/lunarway/snyk_exporter)](https://goreportcard.com/report/github.com/lunarway/snyk_exporter)
 [![Docker Repository on Quay](https://quay.io/repository/lunarway/snyk_exporter/status "Docker Repository on Quay")](https://quay.io/repository/lunarway/snyk_exporter)
 
-Prometheus exporter for [Snyk](https://snyk.io/) written in Go.
-Allows for exporting scanning data into Prometheus by scraping the Snyk HTTP API.
+Prometheus exporter for [Snyk](https://snyk.io/) written in Go. Allows for
+exporting scanning data into Prometheus by scraping the Snyk HTTP API.
 
-# Installation
+## Installation
 
-Several pre-compiled binaries are available from the [releases page](https://github.com/lunarway/snyk_exporter/releases).
+Several pre-compiled binaries are available from the [releases
+page](https://github.com/lunarway/snyk_exporter/releases).
 
-A docker image is also available on our Quay.io registry.
+A Docker image is also available on our Quay.io registry.
 
+```shell
+docker run grafana/snyk_exporter:latest --snyk.api-token '<api-token>'
 ```
-docker run grafana/snyk_exporter:latest --snyk.api-token <api-token>
-```
 
-# Usage
+## Usage
 
-You need a Snyk API token to access to API.
-Get your through the [Snyk account settings](https://app.snyk.io/account/).
+You need a Snyk API token to access to API. Get your through the [Snyk account
+settings](https://app.snyk.io/account/).
 
 It exposes prometheus metrics on `/metrics` on port `9532` (can be configured).
 
-```
-snyk_exporter --snyk.api-token <api-token>
+```shell
+snyk_exporter --snyk.api-token '<api-token>'
 ```
 
 See all configuration options with the `--help` flag
 
-```
+```text
 $ snyk_exporter --help
 usage: snyk_exporter --snyk.api-token=SNYK.API-TOKEN [<flags>]
 
-Snyk exporter for Prometheus. Provide your Snyk API token and the organization(s) to scrape to expose Prometheus metrics.
+Snyk exporter for Prometheus. Provide your Snyk API token and the organization(s) to scrape to
+expose Prometheus metrics.
 
 Flags:
   -h, --help               Show context-sensitive help (also try --help-long and --help-man).
       --snyk.api-url="https://snyk.io/api/v1"
-                           Snyk API URL
+                           Snyk API URL (legacy)
+      --snyk.rest-api-url="https://api.snyk.io/rest"
+                           Snyk REST API URL
+      --snyk.rest-api-version="2023-06-22"
+                           Snyk REST API Version
       --snyk.api-token=SNYK.API-TOKEN
                            Snyk API token
   -i, --snyk.interval=600  Polling interval for requesting data from Snyk API in seconds
       --snyk.organization=SNYK.ORGANIZATION ...
-                           Snyk organization ID to scrape projects from (can be repeated for multiple organizations)
-      --snyk.target=SNYK.TARGET ...  
-                           Snyk target/repo name to scrape projects from (can be repeated for multiple targets)
+                           Snyk organization ID to scrape projects from (can be repeated for
+                           multiple organizations)
+      --snyk.target=SNYK.TARGET ...
+                           Snyk target/repo name to scrape projects from (can be repeated for
+                           multiple targets)
+      --snyk.origin=SNYK.ORIGIN ...
+                           Snyk project origin (can be repeated for multiple origins)
+      --snyk.project-filter=SNYK.PROJECT-FILTER
+                           Project filter (e.g. attributes.imageCluster=mycluster).
       --snyk.timeout=10    Timeout for requests against Snyk API
       --web.listen-address=":9532"
                            Address on which to expose metrics.
-      --log.level="info"   Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]
+      --log.level="info"   Only log messages with the given severity or above. Valid levels:
+                           [debug, info, warn, error, fatal]
       --log.format="logger:stderr"
-                           Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
+                           Set the log target and format. Example:
+                           "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true"
       --version            Show application version.
-
 ```
 
-It is possible to use a file to pass arguments to the exporter.
-For example:
+It is possible to use a file to pass arguments to the exporter. For example:
+
+```shell
+echo '--snyk.api-token=<api-token>' > args
 ```
- echo --snyk.api-token=<>\n > args
-```
+
 And run the exporter using:
-```
+
+```shell
 ./snyk-exporter @args
 ```
 
-# Design
+## Design
 
-The exporter starts a long-running go routine on startup that scrapes the Snyk API with a fixed interval (default every `10` minutes).
-The interval can be configured as needed.
+The exporter starts a long-running go routine on startup that scrapes the Snyk
+API with a fixed interval (default every `10` minutes). The interval can be
+configured as needed.
 
-The API results are aggregated and recorded on the `snyk_vulnerabiilities_total` metric with the following labels:
+The API results are aggregated and recorded on the `snyk_vulnerabilities_total`
+metric with the following labels:
 
 - `organization` - The organization where the vulnerable project exists
 - `target` - The target/repo name of the vulnerable project
@@ -80,7 +97,8 @@ The API results are aggregated and recorded on the `snyk_vulnerabiilities_total`
 - `project_type` - The type of the project (`npm`, `maven`, `rubygems`, etc.)
 - `severity` - The severity of the vulnerability, can be `critical`, `high`, `medium` and `low`
 - `issue_type` - The type of issue, e.g. `vuln`, `license`
-- `issue_title` - The issue title of the vulnerability, e.g. `Denial os Service (DoS)`. Can be the CVE if the vulnerability is not named by Snyk
+- `issue_title` - The issue title of the vulnerability, e.g. `Denial os Service
+  (DoS)`. Can be the CVE if the vulnerability is not named by Snyk
 - `ignored` - The issue is ignored in Snyk.
 - `upgradeable` - The issue can be fixed by upgrading to a later version of the dependency.
 - `patchable` - The issue is patchable through Snyk.
@@ -88,46 +106,51 @@ The API results are aggregated and recorded on the `snyk_vulnerabiilities_total`
 
 Here is an example.
 
-```
+```text
 snyk_vulnerabilities_total{organization="my-org",target="my-scm-org/repo",project="my-app",project_type="npm",severity="critical",issue_type="vuln",issue_title="Remote Code Execution",ignored="false",upgradeable="false",patchable="false",monitored="true"} 1.0
 snyk_vulnerabilities_total{organization="my-org",target="my-scm-org/repo",project="my-app",project_type="npm",severity="high",issue_type="vuln",issue_title="Privilege Escalation",ignored="false",upgradeable="false",patchable="false",monitored="true"} 1.0
 snyk_vulnerabilities_total{organization="my-org",target="my-scm-org/repo",project="my-app",project_type="npm",severity="low",issue_type="vuln",issue_title="Sandbox (chroot) Escape",ignored="true",upgradeable="false",patchable="false",monitored="false"} 2.0
 snyk_vulnerabilities_total{organization="my-org",target="my-scm-org/repo",project="my-app",project_type="npm",severity="medium",issue_type="license",issue_title="MPL-2.0 license",ignored="true",upgradeable="false",patchable="false",monitored="true"} 1
 ```
 
-# Build
+## Build
 
-The exporter can be build using the standard Go tool chain if you have it available.
+The exporter can be build using the standard Go tool chain if you have it
+available.
 
-```
+```shell
 go build
 ```
 
-You can build inside a docker image as well.
-This produces a `snyk_exporter` image that can run with the binary as entry point.
+You can build inside a Docker image as well. This produces a `snyk_exporter`
+image that can run with the binary as entry point.
 
-```
+```shell
 docker build -t snyk_exporter .
 ```
 
-This is useful if the exporter is to be depoyled in Kubernetes or other dockerized environments.
+This is useful if the exporter is to be depoyled in Kubernetes or other
+dockerized environments.
 
 Here is an example of running the exporter locally.
 
-```
-$ docker run -p9532:9532 snyk_exporter --snyk.api-token <api-token>
-time="2019-01-11T09:42:34Z" level=info msg="Starting Snyk exporter for all organization for token" source="main.go:55"
-time="2019-01-11T09:42:34Z" level=info msg="Listening on :9532" source="main.go:63"
-time="2019-01-11T09:42:35Z" level=info msg="Running Snyk API scraper for organizations: <omitted>" source="main.go:106"
+```shell
+docker run -p9532:9532 snyk_exporter --snyk.api-token <api-token>
 ```
 
-# Deployment
+## Deployment
 
-To deploy the exporter in Kubernetes, you can find a simple Kubernetes deployment and secret yaml in the `examples` folder. You have to add your snyk token in the `secrets.yaml` and/or the snyk organizations that you want to get metrics from in the args section of the `deployment.yaml`. If you don't specify a snyk-organization, the exporter will scrape all organizations the token provides access to. The examples assumes that you have a namespace in kubernetes named: `monitoring`.
+To deploy the exporter in Kubernetes, you can find a simple Kubernetes deployment
+and secret yaml in the `examples` folder. You have to add your Snyk token in the
+`secrets.yaml` and/or the snyk organizations that you want to get metrics from in
+the args section of the `deployment.yaml`. If you don't specify a
+snyk-organization, the exporter will scrape all organizations the token provides
+access to. The examples assumes that you have a namespace in Kubernetes named:
+`monitoring`.
 
 It further assumes that you have [kubernetes service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) configured for you Prometheus instance and a target that will gather metrics from pods, similar to this:
 
-```
+```yaml
 - job_name: 'kubernetes-pods'
   kubernetes_sd_configs:
   - role: pod
@@ -151,27 +174,32 @@ It further assumes that you have [kubernetes service discovery](https://promethe
 
 To deploy it to your kubernetes cluster run the following commands:
 
-```
+```shell
 kubectl apply -f examples/secrets.yaml
 kubectl apply -f examples/deployment.yaml
 ```
 
 The exporter expose http endpoints that can be used by kubernetes probes:
-* `/healthz` - used for liveness probe, always returns `healthy`, status code 200.
-* `/ready` - used for readiness probe, return `true` and status code 200 after the first scrape completed. Otherwise, it returns `false`, with status code 503.
 
-# Development
+- `/healthz` - used for liveness probe, always returns `healthy`, status code 200.
+- `/ready` - used for readiness probe, return `true` and status code 200 after
+  the first scrape completed. Otherwise, it returns `false`, with status code 503.
 
-The project uses Go modules so you need Go version >=1.11 to run it.
-Run builds and tests with the standard Go tool chain.
+## Development
+
+The project uses Go modules so you need Go version >=1.11 to run it. Run builds
+and tests with the standard Go tool chain.
 
 ```go
 go build
 go test
 ```
 
-# Credits
-This exporter is written with inspiration from [dnanexus/prometheus_snyk_exporter](https://github.com/dnanexus/prometheus_snyk_exporter).
+## Credits
 
-Main difference is the aggregations are done by Prometheus instead of in the exporter.
-It also scrapes the Snyk API asyncronously, ie. not when Prometheus tries to scrape the metrics.
+This exporter is written with inspiration from
+[dnanexus/prometheus_snyk_exporter](https://github.com/dnanexus/prometheus_snyk_exporter).
+
+Main difference is the aggregations are done by Prometheus instead of in the
+exporter. It also scrapes the Snyk API asyncronously, ie. not when Prometheus
+tries to scrape the metrics.

--- a/examples/snyk-dashboard.json
+++ b/examples/snyk-dashboard.json
@@ -1,4 +1,47 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -24,105 +67,101 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 38,
+  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 83,
+      "id": 203,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
-          },
-          "refId": "A"
-        }
-      ],
-      "title": "Dashboard Row",
+      "title": "Summary",
       "type": "row"
     },
     {
-      "columns": [],
       "datasource": {
-        "uid": "grafanacloud-secdev-prom"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
-      "fontSize": "100%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-background"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
         "y": 1
       },
-      "height": "300px",
       "id": 82,
       "links": [],
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 2,
-        "desc": true
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Total vulnerabilities"
+          }
+        ]
       },
-      "styles": [
-        {
-          "alias": "Time",
-          "align": "auto",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "hidden"
-        },
-        {
-          "alias": "Total Vulnerabilities",
-          "align": "auto",
-          "colorMode": "row",
-          "colors": [
-            "rgba(50, 172, 45, 0.97)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(245, 54, 54, 0.9)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "pattern": "Value",
-          "thresholds": [
-            "1",
-            "5"
-          ],
-          "type": "number",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "short"
-        }
-      ],
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
-            "uid": "grafanacloud-secdev-prom"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(snyk_vulnerabilities_total) by (project)",
+          "editorMode": "code",
+          "expr": "sum(snyk_vulnerabilities_total{project=~\"$project\"}) by (project)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -131,9 +170,24 @@
           "refId": "A"
         }
       ],
-      "title": "Total Vulnerabilities per Project",
-      "transform": "table",
-      "type": "table-old"
+      "title": "Total vulnerabilities per project",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Total vulnerabilities",
+              "project": "Project",
+              "severity": "Severity"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -149,7 +203,8 @@
       },
       "id": 84,
       "panels": [],
-      "repeat": "Project",
+      "repeat": "project",
+      "repeatDirection": "h",
       "targets": [
         {
           "datasource": {
@@ -159,12 +214,163 @@
           "refId": "A"
         }
       ],
-      "title": "$Project",
+      "title": "$project",
       "type": "row"
     },
     {
       "datasource": {
-        "uid": "grafanacloud-secdev-prom"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 70,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "high"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#bf1b00",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "low"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#447ebc",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "medium"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#c15c17",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 16,
+        "x": 0,
+        "y": 10
+      },
+      "id": 1,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(severity) (snyk_vulnerabilities_total{project=~\"$project\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{severity}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Issue count",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -173,26 +379,21 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "N/A"
+                  "index": 0,
+                  "text": "0"
                 }
               },
               "type": "special"
             }
           ],
+          "min": 0,
+          "noValue": "0",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(41, 156, 70, 0)",
+                "color": "dark-red",
                 "value": null
-              },
-              {
-                "color": "rgba(137, 15, 2, 0.49)",
-                "value": 1
-              },
-              {
-                "color": "#d44a3a",
-                "value": 5
               }
             ]
           },
@@ -201,16 +402,16 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 3,
         "w": 2,
-        "x": 0,
+        "x": 16,
         "y": 10
       },
-      "id": 3,
+      "id": 139,
       "links": [],
       "maxDataPoints": 100,
       "options": {
-        "colorMode": "background",
+        "colorMode": "background_solid",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
@@ -223,13 +424,90 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.6-10b38e80",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
-            "uid": "grafanacloud-secdev-prom"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(snyk_vulnerabilities_total{severity=\"high\", project=\"$Project\"})",
+          "editorMode": "code",
+          "expr": "sum(snyk_vulnerabilities_total{severity=\"critical\", project=~\"$project\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Critical",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "index": 0,
+                  "text": "0"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-orange",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 18,
+        "y": 10
+      },
+      "id": 3,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background_solid",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(snyk_vulnerabilities_total{severity=\"high\", project=~\"$project\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -243,7 +521,8 @@
     },
     {
       "datasource": {
-        "uid": "grafanacloud-secdev-prom"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -252,7 +531,8 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "N/A"
+                  "index": 0,
+                  "text": "0"
                 }
               },
               "type": "special"
@@ -262,16 +542,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(41, 156, 70, 0)",
+                "color": "dark-yellow",
                 "value": null
-              },
-              {
-                "color": "rgba(193, 92, 23, 0.49)",
-                "value": 1
-              },
-              {
-                "color": "#c15c17",
-                "value": 5
               }
             ]
           },
@@ -280,16 +552,16 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 3,
         "w": 2,
-        "x": 2,
+        "x": 20,
         "y": 10
       },
       "id": 4,
       "links": [],
       "maxDataPoints": 100,
       "options": {
-        "colorMode": "background",
+        "colorMode": "background_solid",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
@@ -302,17 +574,20 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.6-10b38e80",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
-            "uid": "grafanacloud-secdev-prom"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(snyk_vulnerabilities_total{severity=\"medium\", project=\"$Project\"})",
+          "editorMode": "code",
+          "expr": "sum(snyk_vulnerabilities_total{severity=\"medium\", project=~\"$project\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -321,7 +596,8 @@
     },
     {
       "datasource": {
-        "uid": "grafanacloud-secdev-prom"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -330,7 +606,8 @@
               "options": {
                 "match": "null",
                 "result": {
-                  "text": "N/A"
+                  "index": 0,
+                  "text": "0"
                 }
               },
               "type": "special"
@@ -340,16 +617,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(41, 156, 70, 0)",
+                "color": "dark-blue",
                 "value": null
-              },
-              {
-                "color": "rgba(10, 67, 124, 0.51)",
-                "value": 1
-              },
-              {
-                "color": "#0a437c",
-                "value": 5
               }
             ]
           },
@@ -358,16 +627,16 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 3,
         "w": 2,
-        "x": 4,
+        "x": 22,
         "y": 10
       },
       "id": 5,
       "links": [],
       "maxDataPoints": 100,
       "options": {
-        "colorMode": "background",
+        "colorMode": "background_solid",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
@@ -380,17 +649,20 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.6-10b38e80",
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
-            "uid": "grafanacloud-secdev-prom"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(snyk_vulnerabilities_total{severity=\"low\", project=\"$Project\"})",
+          "editorMode": "code",
+          "expr": "sum(snyk_vulnerabilities_total{severity=\"low\", project=~\"$project\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
+          "range": true,
           "refId": "A"
         }
       ],
@@ -399,316 +671,122 @@
     },
     {
       "datasource": {
-        "uid": "grafanacloud-secdev-prom"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "fixedColor": "transparent",
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "inspect": false
+          },
           "mappings": [
             {
               "options": {
-                "match": "null",
-                "result": {
-                  "text": "N/A"
+                "critical": {
+                  "color": "dark-red",
+                  "index": 0,
+                  "text": "Critical"
+                },
+                "high": {
+                  "color": "dark-orange",
+                  "index": 1,
+                  "text": "High"
+                },
+                "low": {
+                  "color": "dark-blue",
+                  "index": 3,
+                  "text": "Low"
+                },
+                "medium": {
+                  "color": "dark-yellow",
+                  "index": 2,
+                  "text": "Medium"
                 }
               },
-              "type": "special"
+              "type": "value"
             }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgba(41, 156, 70, 0)",
+                "color": "transparent",
                 "value": null
-              },
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Severity"
+            },
+            "properties": [
               {
-                "color": "rgba(10, 67, 124, 0.51)",
-                "value": 1
-              },
-              {
-                "color": "#0a437c",
-                "value": 5
+                "id": "custom.width",
+                "value": 75
               }
             ]
           },
-          "unit": "none"
-        },
-        "overrides": []
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 75
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 7,
-        "w": 2,
-        "x": 6,
-        "y": 10
-      },
-      "id": 139,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.1.6-10b38e80",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "grafanacloud-secdev-prom"
-          },
-          "expr": "sum(snyk_vulnerabilities_total{ignored=\"true\", project=\"$Project\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Ignored",
-      "type": "stat"
-    },
-    {
-      "aliasColors": {
-        "high": "#bf1b00",
-        "low": "#447ebc",
-        "medium": "#c15c17"
-      },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "uid": "grafanacloud-secdev-prom"
-      },
-      "fill": 7,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 10
-      },
-      "height": "",
-      "hiddenSeries": false,
-      "id": 1,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "sortDesc": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "9.1.6-10b38e80",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "uid": "grafanacloud-secdev-prom"
-          },
-          "expr": "sum by(severity) (snyk_vulnerabilities_total{project=~\"$Project\"})",
-          "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{severity}}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Issue Count History",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "columns": [],
-      "datasource": {
-        "uid": "grafanacloud-secdev-prom"
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 8,
         "x": 16,
-        "y": 10
+        "y": 13
       },
       "id": 81,
       "links": [],
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 2,
-        "desc": true
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Severity"
+          }
+        ]
       },
-      "styles": [
-        {
-          "alias": "Time",
-          "align": "auto",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "hidden"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "pattern": "__name__",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "pattern": "instance",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "pattern": "job",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "pattern": "project",
-          "thresholds": [],
-          "type": "hidden",
-          "unit": "short"
-        },
-        {
-          "alias": "Count",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "pattern": "Value",
-          "thresholds": [],
-          "type": "number",
-          "unit": "none"
-        },
-        {
-          "alias": "",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "",
-          "thresholds": [],
-          "type": "number",
-          "unit": "short"
-        },
-        {
-          "alias": "Title",
-          "align": "auto",
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "decimals": 2,
-          "pattern": "issue_title",
-          "thresholds": [],
-          "type": "number",
-          "unit": "short"
-        }
-      ],
+      "pluginVersion": "10.0.2",
       "targets": [
         {
           "datasource": {
-            "uid": "grafanacloud-secdev-prom"
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(snyk_vulnerabilities_total{project=\"$Project\"}) by (issue_title)",
+          "editorMode": "code",
+          "expr": "sum(snyk_vulnerabilities_total{project=~\"$project\"}) by (issue_title, severity)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -717,39 +795,69 @@
           "refId": "A"
         }
       ],
-      "title": "Issues by Type",
-      "transform": "table",
-      "type": "table-old"
+      "title": "Issues by type",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Count",
+              "issue_title": "Title",
+              "severity": "Severity"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
-  "refresh": "",
-  "schemaVersion": 37,
+  "refresh": "5m",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
-          "tags": [],
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "selected": false,
+          "text": "default",
+          "value": "default"
         },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
         "datasource": {
-          "uid": "grafanacloud-secdev-prom"
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "query_result(topk(10, sort_desc(sum(snyk_vulnerabilities_total) by (project))))",
         "hide": 0,
         "includeAll": true,
+        "label": "Project",
         "multi": true,
-        "name": "Project",
+        "name": "project",
         "options": [],
-        "query": "query_result(topk(10, sort_desc(sum(snyk_vulnerabilities_total) by (project))))",
-        "refresh": 1,
+        "query": {
+          "query": "query_result(topk(10, sort_desc(sum(snyk_vulnerabilities_total) by (project))))",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
         "regex": ".*project=\"(.*)\".*",
         "skipUrlSync": false,
         "sort": 0,
@@ -761,7 +869,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -790,8 +898,8 @@
     ]
   },
   "timezone": "",
-  "title": "Snyk Dashboard",
-  "uid": "SwnPHSLGz",
-  "version": 1,
+  "title": "Snyk Exporter",
+  "uid": "a3565fa5-3e33-41ad-9456-d2045b145a30",
+  "version": 2,
   "weekStart": ""
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
+require github.com/guillaumeblaquiere/jsonFilter v0.3.0
+
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/guillaumeblaquiere/jsonFilter v0.3.0 h1:SSF/ddHM36HF5/fr92R2TZks5LygTS0qYVrmEPFXCgM=
+github.com/guillaumeblaquiere/jsonFilter v0.3.0/go.mod h1:SkSeuPRwJW3Gk/0qUqfFw0MkDnXkpud4nxFa9nWPato=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
This PR is adding the possibility to specify the `--snyk.origin` and the `--snyk.project-filter` command line options to further filter which projects will be scraped from the Snyk API. Those options can significantly reduce the time needed to collect data from the Snyk API. The first option allows to filter only specific Snyk origins (Kubernetes, CLI, GitHub, ECR, ...) where the second one allows to use additional [filters on the JSON data](https://github.com/guillaumeblaquiere/jsonFilter#filter-format).

I have also updated the `README.md` file with relevant information and the Grafana dashboard to work with the latest Grafana version.